### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/Web/Chione.hs
+++ b/Web/Chione.hs
@@ -268,7 +268,7 @@ getURLResponse :: String -> IO URLResponse
 -- getURLResponse url | "http://scholar.google.com/" `isPrefixOf` url = return $ URLResponse [200] 999
 getURLResponse url | "http://dl.acm.org/" `isPrefixOf` url = return $ URLResponse [200] 999
 getURLResponse url | "http://doi.acm.org/" `isPrefixOf` url = return $ URLResponse [200] 999
-getURLResponse url | "http://dx.doi.org/" `isPrefixOf` url = return $ URLResponse [200] 999
+getURLResponse url | "https://doi.org/" `isPrefixOf` url = return $ URLResponse [200] 999
 getURLResponse url | "http://portal.acm.org/" `isPrefixOf` url = return $ URLResponse [200] 999
 getURLResponse url = do
       urlRep <- response1


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!